### PR TITLE
Reduce encoder clock

### DIFF
--- a/MCB.cpp
+++ b/MCB.cpp
@@ -28,7 +28,7 @@ int MCB::init(void)
 	
 	// initialize encoder clock used by all LS7366R 
 	si5351_.init(SI5351_CRYSTAL_LOAD_8PF, 0);
-	si5351_.set_freq(2000000000ULL, 0ULL, SI5351_CLK0); // [hundreths of Hz] Set CLK1 to output 20 MHz (max frequency when LS7366R Vdd = 3.3V)
+	si5351_.set_freq(100000000ULL, 0ULL, SI5351_CLK0); // [hundreths of Hz] Set CLK0 to output 1 MHz
 	si5351_.output_enable(SI5351_CLK1, 0); // Disable other clocks
 	si5351_.output_enable(SI5351_CLK2, 0);
 	

--- a/MCB_FSM.cpp
+++ b/MCB_FSM.cpp
@@ -228,7 +228,7 @@ MCBstate RosInit(void)
 
 	// repeatedly attempt to setup the hardware, loop on fail, stop on success
 	while ((nh.getHardware()->error() < 0) && (modeState == Ros)) {
-		Serial.print(F("WIZnet eror = "));
+		Serial.print(F("WIZnet error = "));
 		Serial.println(nh.getHardware()->error());
 
 		nh.initNode();


### PR DESCRIPTION
Reduced encoder clock (Si5351) from 20 MHz to 1 MHz; experimentally found to work better.
Fixed typo.